### PR TITLE
Speed up Fedora adapter.

### DIFF
--- a/app/persistence/valkyrie/persistence/fedora/persister.rb
+++ b/app/persistence/valkyrie/persistence/fedora/persister.rb
@@ -45,15 +45,17 @@ module Valkyrie::Persistence::Fedora
       end
 
       def process_members
-        new_members.each do |member|
-          orm_object.ordered_members << member
+        member_predicate = orm_object.association(:members).reflection.options[:has_member_relation]
+        new_member_ids.each do |member|
+          # orm_object.members_will_change!
+          orm_object.resource << [orm_object.resource.rdf_subject, member_predicate, ActiveFedora::Base.id_to_uri(member)]
+          length = orm_object.ordered_member_proxies.to_a.length
+          orm_object.ordered_member_proxies.insert_target_id_at(length, member)
         end
       end
 
-      def new_members
-        (member_ids - orm_member_ids).map do |member_id|
-          ActiveFedora::Base.find(member_id)
-        end
+      def new_member_ids
+        member_ids - orm_member_ids
       end
 
       def orm_member_ids

--- a/config/valkyrie.yml
+++ b/config/valkyrie.yml
@@ -5,6 +5,7 @@ development:
 
 test:
   <<: *defaults
+  adapter: memory
 
 production:
   <<: *defaults


### PR DESCRIPTION
This adds IDs instead of full ActiveFedora objects when persisting the members list. The benchmark difference can be seen below. Basically adding 100 children all at once goes from 14s to 2.4s.

https://gist.github.com/tpendragon/9d8c22a6d4cef66b27872955608ba8e3