### PR TITLE
Standardize the Value Mapper pattern

### DIFF
--- a/app/services/value_mapper.rb
+++ b/app/services/value_mapper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+class ValueMapper
+  def self.register(value_caster)
+    self.value_casters += [value_caster]
+  end
+
+  def self.value_casters
+    @value_casters ||= []
+  end
+
+  class << self
+    attr_writer :value_casters
+  end
+
+  def self.for(value)
+    (value_casters + [self]).find do |value_caster|
+      value_caster.handles?(value)
+    end.new(value, self)
+  end
+
+  def self.handles?(_value)
+    true
+  end
+
+  attr_reader :value, :calling_mapper
+  def initialize(value, calling_mapper)
+    @value = value
+    @calling_mapper = calling_mapper
+  end
+
+  def result
+    value
+  end
+end

--- a/spec/persistence/valkyrie/persistence/solr/mapper_spec.rb
+++ b/spec/persistence/valkyrie/persistence/solr/mapper_spec.rb
@@ -3,14 +3,16 @@ require 'rails_helper'
 
 RSpec.describe Valkyrie::Persistence::Solr::Mapper do
   subject(:mapper) { described_class.new(resource) }
-  let(:resource) { instance_double(Book, id: "1", title: ["Test"], author: ["Author"], attributes: { title: nil, author: nil, id: nil }) }
+  let(:resource) { instance_double(Book, id: "1", title: ["Test", RDF::Literal.new("French", language: :fr)], author: ["Author"], attributes: { title: nil, author: nil, id: nil }) }
 
   describe "#to_h" do
     it "maps all available properties to the solr record" do
       expect(mapper.to_h).to eq(
         id: "id-#{resource.id}",
-        title_ssim: ["Test"],
-        title_tesim: ["Test"],
+        title_ssim: ["Test", "French"],
+        title_tesim: ["Test", "French"],
+        title_lang_ssim: ["eng", "fr"],
+        title_lang_tesim: ["eng", "fr"],
         author_ssim: ["Author"],
         author_tesim: ["Author"]
       )

--- a/spec/services/value_mapper_spec.rb
+++ b/spec/services/value_mapper_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ValueMapper do
+  before do
+    class SubMapper < ValueMapper
+    end
+    class TestMapper < SubMapper
+      SubMapper.register(self)
+      def self.handles?(value)
+        value == 1
+      end
+
+      def result
+        "yo"
+      end
+    end
+  end
+  after do
+    Object.send(:remove_const, :SubMapper)
+    Object.send(:remove_const, :TestMapper)
+  end
+  it "doesn't share value casters with parent" do
+    expect(described_class.value_casters).to eq []
+    expect(SubMapper.value_casters).to eq [TestMapper]
+  end
+
+  describe "#result" do
+    context "when not handled by a registered handler" do
+      it "returns the given value back" do
+        expect(SubMapper.for(2).result).to eq 2
+      end
+    end
+    context "when handled by a registered handler" do
+      it "returns that handler's result" do
+        expect(SubMapper.for(1).result).to eq "yo"
+      end
+    end
+  end
+end


### PR DESCRIPTION
I was doing a lot of really similar work to convert values between states in a maintainable way in the various persisters. This makes them all use the same standard value mapper registration backend and contract.