### PR TITLE
Add shared specs for Valkyrie::Model

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Book
-  include Valkyrie::ActiveModel
+  include Valkyrie::Model
   attribute :id, Valkyrie::ID::Attribute
   attribute :title, UniqueNonBlankArray
   attribute :author, UniqueNonBlankArray

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Page
-  include Valkyrie::ActiveModel
+  include Valkyrie::Model
   attribute :id, Valkyrie::ID::Attribute
   attribute :title, UniqueNonBlankArray
   attribute :viewing_hint, UniqueNonBlankArray

--- a/lib/valkyrie/active_model.rb
+++ b/lib/valkyrie/active_model.rb
@@ -13,7 +13,7 @@ module Valkyrie
   end
 
   module_function :config
-  module ActiveModel
+  module Model
     def self.included(base)
       base.include Virtus.model
       base.extend ClassMethods

--- a/lib/valkyrie/specs/shared_specs.rb
+++ b/lib/valkyrie/specs/shared_specs.rb
@@ -2,3 +2,4 @@
 require 'valkyrie/specs/shared_specs/persister.rb'
 require 'valkyrie/specs/shared_specs/queries.rb'
 require 'valkyrie/specs/shared_specs/adapter.rb'
+require 'valkyrie/specs/shared_specs/model.rb'

--- a/lib/valkyrie/specs/shared_specs/model.rb
+++ b/lib/valkyrie/specs/shared_specs/model.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+RSpec.shared_examples 'a Valkyrie::Model' do
+  before do
+    raise 'model_klass must be set with `let(:model_klass)`' unless
+      defined? model_klass
+  end
+  describe "#id" do
+    it "can be set via instantiation and casts to a Valkyrie::ID" do
+      resource = model_klass.new(id: "test")
+      expect(resource.id).to eq Valkyrie::ID.new("test")
+    end
+
+    it "is nil when not set" do
+      resource = model_klass.new
+      expect(resource.id).to be_nil
+    end
+
+    it { is_expected.to respond_to(:persisted?).with(0).arguments }
+    it { is_expected.to respond_to(:to_param).with(0).arguments }
+    it { is_expected.to respond_to(:to_model).with(0).arguments }
+    it { is_expected.to respond_to(:model_name).with(0).arguments }
+    it { is_expected.to respond_to(:resource_class).with(0).arguments }
+    it { is_expected.to respond_to(:column_for_attribute).with(1).arguments }
+
+    describe "#has_attribute?" do
+      it "returns true when it has a given attribute" do
+        resource = model_klass.new
+        expect(resource.has_attribute?(:id)).to eq true
+      end
+    end
+
+    describe "#fields" do
+      it "returns a set of fields" do
+        expect(model_klass).to respond_to(:fields).with(0).arguments
+        expect(model_klass.fields).to include(:id)
+      end
+    end
+  end
+end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     raise 'persister must be set with `let(:persister)`' unless
       defined? persister
     class CustomResource
-      include Valkyrie::ActiveModel
+      include Valkyrie::Model
       attribute :id, Valkyrie::ID::Attribute
       attribute :title
       attribute :member_ids

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Book do
   subject(:book) { described_class.new }
+  let(:model_klass) { described_class }
+  it_behaves_like "a Valkyrie::Model"
 
   describe "#title" do
     it "is an accessor" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Page do
+  subject(:book) { described_class.new }
+  let(:model_klass) { described_class }
+  it_behaves_like "a Valkyrie::Model"
+end

--- a/spec/persistence/valkyrie/persistence/solr/persister_spec.rb
+++ b/spec/persistence/valkyrie/persistence/solr/persister_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Valkyrie::Persistence::Solr::Persister do
         end
       end
       class Resource
-        include Valkyrie::ActiveModel
+        include Valkyrie::Model
         attribute :id, String
         attribute :title, UniqueNonBlankArray
         attribute :other_title, UniqueNonBlankArray


### PR DESCRIPTION
Also renames Valkyrie::ActiveModel to Valkyrie::Model to be clearer.