### PR TITLE
Add support for integer values

### DIFF
--- a/app/persistence/valkyrie/persistence/solr/mapper.rb
+++ b/app/persistence/valkyrie/persistence/solr/mapper.rb
@@ -126,6 +126,17 @@ module Valkyrie::Persistence::Solr
         end
       end
 
+      class IntegerPropertyValue < ValueMapper
+        SolrMapperValue.register(self)
+        def self.handles?(value)
+          value.is_a?(Property) && value.value.is_a?(Integer)
+        end
+
+        def result
+          calling_mapper.for(Property.new(value.key, "integer-#{value.value}")).result
+        end
+      end
+
       class SharedStringPropertyValue < ValueMapper
         SolrMapperValue.register(self)
         def self.handles?(value)

--- a/app/persistence/valkyrie/persistence/solr/resource_factory.rb
+++ b/app/persistence/valkyrie/persistence/solr/resource_factory.rb
@@ -125,6 +125,7 @@ module Valkyrie::Persistence::Solr
           Valkyrie::ID.new(value.gsub(/^id-/, ''))
         end
       end
+
       class URIValue < ValueMapper
         SolrValue.register(self)
         def self.handles?(value)
@@ -133,6 +134,17 @@ module Valkyrie::Persistence::Solr
 
         def result
           ::RDF::URI.new(value.gsub(/^uri-/, ''))
+        end
+      end
+
+      class IntegerValue < ValueMapper
+        SolrValue.register(self)
+        def self.handles?(value)
+          value.to_s.start_with?("integer-")
+        end
+
+        def result
+          value.gsub(/^integer-/, '').to_i
         end
       end
     end

--- a/lib/valkyrie/specs/shared_specs/persister.rb
+++ b/lib/valkyrie/specs/shared_specs/persister.rb
@@ -51,6 +51,14 @@ RSpec.shared_examples 'a Valkyrie::Persister' do
     expect(reloaded.title).to contain_exactly RDF::URI("http://test.com")
   end
 
+  it "can store integers" do
+    book = persister.save(model: resource_class.new(title: [1]))
+
+    reloaded = query_service.find_by(id: book.id)
+
+    expect(reloaded.title).to contain_exactly 1
+  end
+
   it "can order members" do
     book = persister.save(model: resource_class.new)
     book2 = persister.save(model: resource_class.new)


### PR DESCRIPTION
I wasn't expecting this, but both the Fedora persister and Postgres persister just worked.